### PR TITLE
For Issue 6

### DIFF
--- a/src/UserOps.cpp
+++ b/src/UserOps.cpp
@@ -261,6 +261,31 @@ std::string UserOps::login(const std::string &keyfilePath) {
     }
     bool adminFlag = (uname == "admin");
     users[uname] = User{uname, keyData, userPub, adminFlag};
+    // if user is admin, open admin_mapping.json and get all users in the list to the in-memory cache
+    if (adminFlag) {
+        std::string adminMappingFileName = SecOps::SecurityOps::sha256("admin_mapping.json");
+        std::string adminMappingPath = "filesystem/" + adminMappingFileName;
+        json adminMapping;
+        if (Ops::FileOps::fileExists(adminMappingPath)) {
+            std::string enc = Ops::FileOps::readFile(adminMappingPath);
+            try {
+                std::string dec = SecOps::SecurityOps::hybridDecrypt(enc, keyData);
+                adminMapping = json::parse(dec);
+            } catch (...) {
+                adminMapping = json::object();
+            }
+        }
+        for (auto &user : adminMapping.items()) {
+            // except for admin itself, add all users to the in-memory cache
+            if (user.key() == "admin") continue;
+            users[user.key()] = User{user.key(), user.value(), "", false};
+        }
+    }
+    // print all users
+    std::cout << "[Debug] All users in memory:\n";
+    for (const auto &user : users) {
+        std::cout << user.first << "\n";
+    }
     return uname;
 }
 


### PR DESCRIPTION
Issue 6 solved

Root Cause:
•	The user list is stored in a file known as admin_mapping.json. It was not populated during admin login.
Solution:
•	Added the functionality during admin login to parse this admin_mapping.json and get the list of users to the in-memory cache.

Screenshots:
![WhatsApp Image 2025-04-18 at 19 02 36_9fc56087](https://github.com/user-attachments/assets/4241758e-ef67-4be0-aeef-1b0343dfc723)

1.	A user “danush” was shared a file.
2.	Tried to create user “danush” again. It failed.
3.	User “danush” could still access the file.
