### PR TITLE
Tulip Issue 5

### DIFF
--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -384,12 +384,15 @@ void InteractiveShell::handle_ls() {
     if (isInPersonalDirectory(currentDir)) {
         json filemap = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
         if (filemap.empty() || !filemap.contains("entries")) {
-            for (auto &entry : std::filesystem::directory_iterator(realDir)) {
-                std::cout << entry.path().filename().string() << "\n";
-            }
+            Ops::FileOps::appendErrorLog("[Debug] handle_ls: user_file_mapping.json is empty or missing 'entries' for " + activeUser,
+                UOps::UserOps::getUser(activeUser));
             return;
         }
         for (auto &item : filemap["entries"].items()) {
+            // hash of current directory
+            std::string hashedDir = SecOps::SecurityOps::sha256(currentDir);
+            // Check if the item is not part of current directory, skip
+            if (item.value()["parent"] != hashedDir) continue;
             if (item.value().contains("name") && item.value().contains("type")) {
                 std::string name = item.value()["name"];
                 std::string type = item.value()["type"];
@@ -569,13 +572,21 @@ void InteractiveShell::handle_mkdir(const std::string &dirname) {
         return;
     }
     if (!Ops::FileOps::makeDirectory(newPath)) {
-        std::cout << "Failed to create directory\n";
+        std::cout << "Failed to create directory\nFiles and directories should have unique names in the same directory.\n";
         return;
     }
     std::cout << "Created directory " << dirname << "\n";
     // Update the user_file_mapping "entries" for the active user.
     std::string activeUser = (currentUser == "admin" && !viewedUser.empty()) ? viewedUser : currentUser;
+    // hash of current directory
+    std::string parentDir = SecOps::SecurityOps::sha256(currentDir);
     json mapping = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
+    if (mapping.empty() || !mapping.contains("entries")) {
+        mapping["entries"] = json::object();
+    }
+    // Add the new directory to the mapping.
+    mapping["entries"][hashed] = { {"name", dirname}, {"type", "d"} , {"parent", parentDir} };
+    // Save the updated mapping.
     mapping["entries"][hashed] = { {"name", dirname}, {"type", "d"} };
     if (!UOps::UserOps::saveUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).publicKey, mapping)) {
         std::cout << "Warning: Failed to update directory mapping.\n";
@@ -629,7 +640,14 @@ void InteractiveShell::handle_mkfile(const std::string &args) {
     std::cout << "Created file " << filename << "\n";
     // Update the user_file_mapping "entries" for the active user.
     json mapping = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
-    mapping["entries"][hashed] = { {"name", filename}, {"type", "f"} };
+    // take hash of current directory
+    std::string parentDir = SecOps::SecurityOps::sha256(currentDir);
+    if (mapping.empty() || !mapping.contains("entries")) {
+        mapping["entries"] = json::object();
+    }
+    // Add the new file to the mapping.
+    mapping["entries"][hashed] = { {"name", filename}, {"type", "f"} , {"parent", parentDir} };
+    // Save the updated mapping.
     if (!UOps::UserOps::saveUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).publicKey, mapping)) {
         std::cout << "Warning: Failed to update file mapping.\n";
     }


### PR DESCRIPTION
**Root Cause:** 
The issue is due to the “ls” command’s code, not “cd”. 
The file mapping for personal folder was not mapped properly in user_file_mapping.json. 
**Solution:** 
Added a property for each entry in the file mapping à “parent” – it stored the hash of the parent directory of the folder or file. 
When “ls” command is executed, it will check if the hash of the current directory matches with hash of the parent directory in each of the entries and if it does, prints the original name of the entry. 

**Screenshots**

<img width="621" alt="Screenshot 2025-04-19 at 9 26 41 PM" src="https://github.com/user-attachments/assets/7adff3c1-73d0-4200-92e4-c2f48d90cd57" />

1. Created directory and a sub-directory. 
2. Using “ls” command, checked personal. 
3. Went into directory and saw that it contains only sub-directory. 
 

