### PR TITLE
Issue 6

### DIFF
--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -242,10 +242,11 @@ void InteractiveShell::handle_cd(const std::string &arg) {
         json admMap;
         if (Ops::FileOps::fileExists(adminMappingPath)) {
             std::string adminPriv = UOps::UserOps::getUser("admin").privateKey;
-            std::string key = adminPriv.substr(0, 32);
+            // Read the admin mapping file.
             std::string enc = Ops::FileOps::readFile(adminMappingPath);
             try {
-                std::string dec = SecOps::SecurityOps::aesDecrypt(enc, key);
+                // Use hybridDecrypt with admin's private key to decrypt the mapping.
+                std::string dec = SecOps::SecurityOps::hybridDecrypt(enc, adminPriv);
                 admMap = json::parse(dec);
             } catch(...) {
                 admMap = json::object();


### PR DESCRIPTION
Root Cause:
•	There is a file admin_mapping.json that contains the user list.
•	The “cd” command needs to decrypt this file to get the users list to go to that target user.
•	
Solution:
•	Added a property for each entry in the file mapping  “parent” – it stored the hash of the parent directory of the folder or file.
•	When “ls” command is executed, it will check if the hash of the current directory matches with hash of the parent directory in each of the entries and if it does, prints the original name of the entry.


Screenshots:
![WhatsApp Image 2025-04-18 at 19 58 47_d158b3be](https://github.com/user-attachments/assets/804815a4-1420-4874-98c0-954cf2e848ce)
1.	There are three users including admin.
2.	Admin logged into danush1
3.	He was able to view the contents of danush1.
