### PR TITLE
Issue 7: Critical Metadata Files not encrypted and not a part of filesystem

### DIFF
--- a/include/SecurityOps.h
+++ b/include/SecurityOps.h
@@ -34,6 +34,9 @@ namespace SecOps {
         // Computes the SHA-256 hash of the input data and returns it as a hexadecimal string.
         static std::string sha256(const std::string &data);
 
+        // Generates a random key of the specified length (in bytes).
+        static std::string generateRandomKey(size_t length);
+
         /**
          * hybridEncrypt:
          * Implements hybrid encryption:

--- a/include/UserOps.h
+++ b/include/UserOps.h
@@ -47,8 +47,11 @@ namespace UOps {
         // userExists: checks if user is in the in-memory cache.
         static bool userExists(const std::string &username);
 
-        // mapUser: updates global_mapping.json with user root, shared, etc.
-        static bool mapUser(const std::string &username, const std::string &publicKey);
+        // loadGlobalMapping: loads global_mapping.json and returns the mapping.
+        static json loadGlobalMapping(const User &user);
+
+        // saveGlobalMap: saves the global mapping to global_mapping.json.
+        static bool saveGlobalMap(const json &j, const User &user);
 
         // updateAdminMapping: updates admin_mapping.json with user private key, encrypted with admin's private key.
         static bool updateAdminMapping(const std::string &username, const std::string &userPrivateKey, const std::string &adminPrivateKey);
@@ -58,6 +61,8 @@ namespace UOps {
 
         // Public helper to save the user's encrypted file mapping.
         static bool saveUserFileMappingPublic(const std::string &username, const std::string &userPub, const json &mapping);
+
+
 
         // In-memory cache of users.
         static std::unordered_map<std::string, User> users;

--- a/src/SecurityOps.cpp
+++ b/src/SecurityOps.cpp
@@ -193,6 +193,14 @@ std::string SecurityOps::rsaDecrypt(const std::string &data, const std::string &
     return std::string(reinterpret_cast<char*>(outbuf.data()), outlen);
 }
 
+// function to generate a random key of given length
+std::string SecurityOps::generateRandomKey(size_t length) {
+    std::vector<unsigned char> key(length);
+    if (!RAND_bytes(key.data(), length))
+        throw std::runtime_error("Failed to generate random key: " + getOpenSSLError());
+    return std::string(reinterpret_cast<char*>(key.data()), length);
+}
+
 std::string SecurityOps::aesEncrypt(const std::string &plaintext, const std::string &key) {
     if (key.size() != 32)
         throw std::runtime_error("AES key must be 32 bytes for AES-256. " + getOpenSSLError());

--- a/src/Shell.cpp
+++ b/src/Shell.cpp
@@ -13,22 +13,6 @@
 using json = nlohmann::json;
 
 namespace {
-    static const std::string GLOBAL_MAPPING_FILE = "global_mapping.json";
-
-    // Load global mapping from "global_mapping.json"
-    json loadGlobalMapping() {
-        std::ifstream ifs(GLOBAL_MAPPING_FILE);
-        if (!ifs) return json::object();
-        json j;
-        ifs >> j;
-        return j;
-    }
-
-    bool saveGlobalMapping(const json &j) {
-        std::ofstream ofs(GLOBAL_MAPPING_FILE);
-        ofs << j.dump(4);
-        return ofs.good();
-    }
 
     // Check if the virtual path is in the personal directory.
     bool isInPersonalDirectory(const std::string &vpath) {
@@ -105,7 +89,12 @@ InteractiveShell::InteractiveShell(const std::string &username)
 std::string InteractiveShell::resolvePath(const std::string &vpath) {
     std::string activeUser = (currentUser == "admin" && !viewedUser.empty()) ? viewedUser : currentUser;
     if (vpath.rfind("/shared", 0) == 0) {
-        json global = loadGlobalMapping();
+        
+        json global = UOps::UserOps::loadGlobalMapping(UOps::UserOps::getUser(activeUser));
+        if (global.empty()) {
+            Ops::FileOps::appendErrorLog("[Debug] resolvePath: loadGlobalMapping failed for " + activeUser);
+            return "";
+        }
         std::string sharedHash;
         if (global.contains(activeUser) && global[activeUser].contains("shared"))
             sharedHash = global[activeUser]["shared"];
@@ -242,10 +231,11 @@ void InteractiveShell::handle_cd(const std::string &arg) {
         json admMap;
         if (Ops::FileOps::fileExists(adminMappingPath)) {
             std::string adminPriv = UOps::UserOps::getUser("admin").privateKey;
-            std::string key = adminPriv.substr(0, 32);
+            // Read the admin mapping file.
             std::string enc = Ops::FileOps::readFile(adminMappingPath);
             try {
-                std::string dec = SecOps::SecurityOps::aesDecrypt(enc, key);
+                // Use hybridDecrypt with admin's private key to decrypt the mapping.
+                std::string dec = SecOps::SecurityOps::hybridDecrypt(enc, adminPriv);
                 admMap = json::parse(dec);
             } catch(...) {
                 admMap = json::object();
@@ -359,6 +349,7 @@ void InteractiveShell::handle_ls() {
         std::cout << "shared\n";
         return;
     }
+    
     std::string realDir = resolvePath(currentDir);
     if (!Ops::FileOps::directoryExists(realDir)) {
         std::cout << "Directory does not exist.\n";
@@ -371,7 +362,13 @@ void InteractiveShell::handle_ls() {
 
     // In shared directory, list from global_mapping.
     if (isInSharedDirectory(currentDir)) {
-        json global = loadGlobalMapping();
+        json global = UOps::UserOps::loadGlobalMapping(UOps::UserOps::getUser(activeUser));
+        if (global.empty()) {
+            Ops::FileOps::appendErrorLog("[Debug] handle_ls: global_mapping.json is empty");
+            return;
+        }
+        // Check if the user has shared files and it is not empty.
+        // If the user has shared files, list them.
         if (global.contains(activeUser) && global[activeUser].contains("shared_files")) {
             for (auto &item : global[activeUser]["shared_files"].items()) {
                 std::string displayName = item.value(); // original name
@@ -384,15 +381,18 @@ void InteractiveShell::handle_ls() {
     if (isInPersonalDirectory(currentDir)) {
         json filemap = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
         if (filemap.empty() || !filemap.contains("entries")) {
-            for (auto &entry : std::filesystem::directory_iterator(realDir)) {
-                std::cout << entry.path().filename().string() << "\n";
-            }
+            Ops::FileOps::appendErrorLog("[Debug] handle_ls: user_file_mapping.json is empty or missing 'entries' for " + activeUser);
             return;
         }
         for (auto &item : filemap["entries"].items()) {
+            // hash of current directory
+            std::string hashedDir = SecOps::SecurityOps::sha256(currentDir);
+            // Check if the item is not part of current directory, skip
+            if (item.value()["parent"] != hashedDir) continue;
             if (item.value().contains("name") && item.value().contains("type")) {
                 std::string name = item.value()["name"];
                 std::string type = item.value()["type"];
+                
                 if (type == "d")
                     std::cout << "d -> " << name << "\n";
                 else
@@ -417,7 +417,12 @@ void InteractiveShell::handle_cat(const std::string &filename) {
     std::string hashedName;
     bool found = false;
     if (isInSharedDirectory(currentDir)) {
-        json global = loadGlobalMapping();
+        json global = UOps::UserOps::loadGlobalMapping(UOps::UserOps::getUser(activeUser));
+        if (global.empty()) {
+            Ops::FileOps::appendErrorLog("[Debug] handle_cat: global_mapping.json is empty");
+            return;
+        }
+        // Check if the file exists in the shared_files mapping.
         if (global.contains(activeUser) && global[activeUser].contains("shared_files")) {
             for (auto &it : global[activeUser]["shared_files"].items()) {
                 if (it.value() == filename) {
@@ -521,10 +526,17 @@ void InteractiveShell::handle_share(const std::string &args) {
         return;
     }
     // Update global mapping: add the shared file entry.
-    json global = loadGlobalMapping();
+    json global = UOps::UserOps::loadGlobalMapping(UOps::UserOps::getUser(activeUser));
+    if (global.empty()) {
+        Ops::FileOps::appendErrorLog("[Debug] handle_share: global_mapping.json is empty");
+        return;
+    }
     std::string hashedName = SecOps::SecurityOps::sha256(filename);
     global[targetUser]["shared_files"][hashedName] = filename;
-    saveGlobalMapping(global);
+    // Save the updated global mapping.
+    if (!UOps::UserOps::saveGlobalMap(global, UOps::UserOps::getUser(activeUser))) {
+        Ops::FileOps::appendErrorLog("[Debug] handle_share: failed to save global mapping");
+    }
     // Write the new ciphertext to the target user's shared folder.
     std::string targetSharedHash;
     if (global.contains(targetUser) && global[targetUser].contains("shared"))
@@ -569,14 +581,21 @@ void InteractiveShell::handle_mkdir(const std::string &dirname) {
         return;
     }
     if (!Ops::FileOps::makeDirectory(newPath)) {
-        std::cout << "Failed to create directory\n";
+        std::cout << "Failed to create directory\nFiles and directories should have unique names in the same directory.\n";
         return;
     }
     std::cout << "Created directory " << dirname << "\n";
     // Update the user_file_mapping "entries" for the active user.
     std::string activeUser = (currentUser == "admin" && !viewedUser.empty()) ? viewedUser : currentUser;
+    // hash of current directory
+    std::string parentDir = SecOps::SecurityOps::sha256(currentDir);
     json mapping = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
-    mapping["entries"][hashed] = { {"name", dirname}, {"type", "d"} };
+    if (mapping.empty() || !mapping.contains("entries")) {
+        mapping["entries"] = json::object();
+    }
+    // Add the new directory to the mapping.
+    mapping["entries"][hashed] = { {"name", dirname}, {"type", "d"} , {"parent", parentDir} };
+    // Save the updated mapping.
     if (!UOps::UserOps::saveUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).publicKey, mapping)) {
         std::cout << "Warning: Failed to update directory mapping.\n";
     }
@@ -629,7 +648,14 @@ void InteractiveShell::handle_mkfile(const std::string &args) {
     std::cout << "Created file " << filename << "\n";
     // Update the user_file_mapping "entries" for the active user.
     json mapping = UOps::UserOps::loadUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).privateKey);
-    mapping["entries"][hashed] = { {"name", filename}, {"type", "f"} };
+    // take hash of current directory
+    std::string parentDir = SecOps::SecurityOps::sha256(currentDir);
+    if (mapping.empty() || !mapping.contains("entries")) {
+        mapping["entries"] = json::object();
+    }
+    // Add the new file to the mapping.
+    mapping["entries"][hashed] = { {"name", filename}, {"type", "f"} , {"parent", parentDir} };
+    // Save the updated mapping.
     if (!UOps::UserOps::saveUserFileMappingPublic(activeUser, UOps::UserOps::getUser(activeUser).publicKey, mapping)) {
         std::cout << "Warning: Failed to update file mapping.\n";
     }

--- a/src/UserOps.cpp
+++ b/src/UserOps.cpp
@@ -25,6 +25,32 @@ static const std::string ADMIN_KEYS_DIR   = "admin_keys"; // For admin's final p
  * then encrypts the AES key with RSA (using the user's public key).
  * The output is stored as the file named sha256("user_file_mapping.json") under filesystem/<sha256(username)>.
  */
+
+
+ // Helper function to convert bytes string to hex
+ static std::string bytesToHex(const std::string &bytes) {
+    std::ostringstream oss;
+    for (unsigned char c : bytes) {
+        oss << std::hex << std::setw(2) << std::setfill('0') << static_cast<int>(c);
+    }
+    return oss.str();
+}
+ // Helper function to convert hex to bytes string
+ static std::vector<unsigned char> hexToBytes(const std::string &hex) {
+    if (hex.size() % 2) throw std::runtime_error("Invalid hex length");
+    std::vector<unsigned char> out; out.reserve(hex.size()/2);
+    for (size_t i = 0; i < hex.size(); i += 2) {
+        unsigned int byte;
+        std::stringstream ss;
+        ss << std::hex << hex.substr(i,2);
+        ss >> byte;
+        out.push_back(static_cast<unsigned char>(byte));
+    }
+    return out;
+}
+
+
+
 bool UserOps::createUserFileMapping(const std::string &username, const std::string &userPub) {
     std::string userRoot = "filesystem/" + SecOps::SecurityOps::sha256(username);
     if (!std::filesystem::exists(userRoot)) {
@@ -38,7 +64,20 @@ bool UserOps::createUserFileMapping(const std::string &username, const std::stri
     mapping["entries"]  = json::object();  // To track subfolders/files in personal
     //Store public key fingerprint for later verification
     mapping["public_key"] = SecOps::SecurityOps::sha256(userPub);
-    
+    //Store the key used for global_mapping.json
+    //If user is admin, generate a 32 byte key for global mapping
+    if(username == "admin") {
+        // generate raw random bytes
+        std::string rawkey = SecOps::SecurityOps::generateRandomKey(32);
+        // convert to hex string for JSON storage
+        std::string key = bytesToHex(rawkey);
+        // store the key in the mapping
+        mapping["global_mapping_key"] = key;
+    }else {
+        //For non-admin users, get the key from admin's user_file_mapping.json
+        mapping["global_mapping_key"] = UOps::UserOps::loadUserFileMappingPublic("admin", UOps::UserOps::getUser("admin").privateKey)["global_mapping_key"];
+    }
+
     std::string fileNameHash = SecOps::SecurityOps::sha256("user_file_mapping.json");
     std::string filePath = userRoot + "/" + fileNameHash;
     std::string plain = mapping.dump(4);
@@ -182,11 +221,7 @@ bool UserOps::createUser(const std::string &username) {
         Ops::FileOps::appendErrorLog("[Debug] createUser: createUserFileMapping failed for " + username);
         return false;
     }
-    // Update global mapping.
-    if (!UserOps::mapUser(username, userPub)) {
-        Ops::FileOps::appendErrorLog("[Debug] createUser: mapUser failed for " + username);
-        return false;
-    }
+    
     bool adminFlag = (username == "admin");
     if (adminFlag) {
         if (!UOps::UserOps::updateAdminMapping(username, userPriv, userPub)) {
@@ -194,6 +229,14 @@ bool UserOps::createUser(const std::string &username) {
         }
     }
     users[username] = User{username, userPriv, userPub, adminFlag};
+
+    // Update global mapping with emmpty json variable and users
+    json globalMapping = json::object();
+    if(!UOps::UserOps::saveGlobalMap(globalMapping, users[username])){
+        Ops::FileOps::appendErrorLog("[Debug] Failed to save global mapping for " + username);
+        return false;
+    }
+
     return true;
 }
 
@@ -261,6 +304,26 @@ std::string UserOps::login(const std::string &keyfilePath) {
     }
     bool adminFlag = (uname == "admin");
     users[uname] = User{uname, keyData, userPub, adminFlag};
+    // if user is admin, open admin_mapping.json and get all users in the list to the in-memory cache
+    if (adminFlag) {
+        std::string adminMappingFileName = SecOps::SecurityOps::sha256("admin_mapping.json");
+        std::string adminMappingPath = "filesystem/" + adminMappingFileName;
+        json adminMapping;
+        if (Ops::FileOps::fileExists(adminMappingPath)) {
+            std::string enc = Ops::FileOps::readFile(adminMappingPath);
+            try {
+                std::string dec = SecOps::SecurityOps::hybridDecrypt(enc, keyData);
+                adminMapping = json::parse(dec);
+            } catch (...) {
+                adminMapping = json::object();
+            }
+        }
+        for (auto &user : adminMapping.items()) {
+            // except for admin itself, add all users to the in-memory cache
+            if (user.key() == "admin") continue;
+            users[user.key()] = User{user.key(), user.value(), "", false};
+        }
+    }
     return uname;
 }
 
@@ -277,31 +340,98 @@ User UserOps::getUser(const std::string &username) {
 }
 
 /**
- * mapUser:
- * Updates global_mapping.json for the given user with:
- * - root: hashed username.
- * - shared: hashed "shared".
- * - shared_files: an empty object for later shared file entries.
+ * this function is used to update the global_mapping.json file
+ * with details of the user, including root, shared, and shared_files
+ * the root and shared folders are hashed using sha256
+ * the shared_files is a json object that will be updated through j
+ * the function will create the global_mapping.json file if it does not exist
+ * and will append the user details to it
+ * the function will return true if successful, false otherwise
+ * to get the details of user, use the getUser function
+ * the global_mapping.json file is stored in the filesystem directory
+ * the file is named as sha256("global_mapping.json")
+ * the file is encrypted/decrypted using the global_mapping_key in the user_file_mapping.json and aesencrypt and aesdecrypt
+ * 
  */
-bool UserOps::mapUser(const std::string &username, const std::string &publicKey) {
-    json mapping;
-    std::ifstream ifs("global_mapping.json");
-    if (ifs) {
-        ifs >> mapping;
-        ifs.close();
+json UserOps::loadGlobalMapping(const UOps::User &user) {
+    std::string globalMappingFileName = SecOps::SecurityOps::sha256("global_mapping.json");
+    std::string globalMappingPath = "filesystem/" + globalMappingFileName;
+    json globalMapping;
+    globalMapping = json::object();
+    // Get the global mapping key from the user_file_mapping.json
+    json userFileMapping = loadUserFileMappingPublic(user.username, user.privateKey);
+    if (userFileMapping.empty() || !userFileMapping.contains("global_mapping_key")) {
+        Ops::FileOps::appendErrorLog("[Debug] saveGlobalMap: global_mapping_key not found in user_file_mapping.json for " + user.username);
+        // return empty json object
+        return globalMapping;
     }
-    mapping[username] = {
-        {"root", SecOps::SecurityOps::sha256(username)},
-        {"shared", SecOps::SecurityOps::sha256("shared")},
-        {"shared_files", json::object()}
-    };
-    std::ofstream ofs("global_mapping.json");
-    ofs << mapping.dump(4);
-    if (!ofs.good()) {
-        Ops::FileOps::appendErrorLog("[Debug] mapUser: writing global_mapping.json failed for user " + username);
+    std::string globalMappingKey = userFileMapping["global_mapping_key"];
+    auto keyBytes = hexToBytes(globalMappingKey);
+    std::string keyStr(reinterpret_cast<char*>(keyBytes.data()), keyBytes.size());
+    // Read the global mapping file.
+    // If the file does not exist, create an empty JSON object.
+    if (!Ops::FileOps::fileExists(globalMappingPath)) {
+        Ops::FileOps::appendErrorLog("[Debug] loadGlobalMapping: global_mapping.json not found");
+        
+    } else {
+        std::string enc = Ops::FileOps::readFile(globalMappingPath);
+        try {
+            // Decrypt the global mapping file using the global mapping key.
+            std::string dec = SecOps::SecurityOps::aesDecrypt(enc, keyStr);
+            globalMapping = json::parse(dec);
+            return globalMapping;
+        } catch (...) {
+            Ops::FileOps::appendErrorLog("[Debug] loadGlobalMapping: aesDecrypt failed for " + globalMappingPath);
+            return globalMapping;
+        }
+    }
+    return globalMapping;
+}
+bool UserOps::saveGlobalMap(const json &j, const UOps::User &user) {
+    json globalMapping = loadGlobalMapping(user);
+    if (globalMapping.empty()) {
+        Ops::FileOps::appendErrorLog("[Debug] saveGlobalMap: loadGlobalMapping failed for " + user.username);
+    }
+    // If the user does not exist in the global mapping, add it.
+    if (!globalMapping.contains(user.username)) {
+        globalMapping[user.username] = json::object();
+        globalMapping[user.username]["root"] = SecOps::SecurityOps::sha256(user.username);
+        globalMapping[user.username]["shared"] = SecOps::SecurityOps::sha256("shared");
+        globalMapping[user.username]["shared_files"] = json::object();
+    }
+    // if j is not empty, make the global mapping as j
+    if (!j.empty()) {
+        globalMapping = j;
+    }
+    // write the global mapping file
+    std::string globalMappingFileName = SecOps::SecurityOps::sha256("global_mapping.json");
+    std::string globalMappingPath = "filesystem/" + globalMappingFileName;
+    std::string plain = globalMapping.dump(4);
+    std::string encrypted;
+    // Get the global mapping key from the user_file_mapping.json
+    json userFileMapping = loadUserFileMappingPublic(user.username, user.privateKey);
+    if (userFileMapping.empty() || !userFileMapping.contains("global_mapping_key")) {
+        Ops::FileOps::appendErrorLog("[Debug] saveGlobalMap: global_mapping_key not found in user_file_mapping.json for " + user.username);
+        // return empty json object
+        return globalMapping;
+    }
+    std::string globalMappingKey = userFileMapping["global_mapping_key"];
+    auto keyBytes = hexToBytes(globalMappingKey);
+    std::string keyStr(reinterpret_cast<char*>(keyBytes.data()), keyBytes.size());
+    // Read the global mapping file.
+    try {
+        // Encrypt the global mapping file using the global mapping key.
+        encrypted = SecOps::SecurityOps::aesEncrypt(plain, keyStr);
+    } catch(std::exception &e) {
+        Ops::FileOps::appendErrorLog("[Debug] saveGlobalMap: aesEncrypt failed: " + std::string(e.what()));
+        return false;
+    }
+    if (!Ops::FileOps::writeFile(globalMappingPath, encrypted)) {
+        Ops::FileOps::appendErrorLog("[Debug] saveGlobalMap: writeFile failed for " + globalMappingPath);
         return false;
     }
     return true;
+    
 }
 
 /**


### PR DESCRIPTION
modified:   include/UserOps.h
modified:   src/SecurityOps.cpp
modified:   src/Shell.cpp
modified:   src/UserOps.cpp

**Root Cause:**
•	The file in question shows the directory path to the hash named files and folders (except files and folders in the personal directory of the Users).
•	This file is used by all users to share and access files.
•	Currently this file is open for view.
**Solution:**
•	A constant is created during admin creation which is stored in admin’s user_mapping.json.
•	This is shared each time a new user is created and put in its user_mapping.json.

**Screenshot:**

![image](https://github.com/user-attachments/assets/17d79210-cfd6-4ca4-aad6-99548b5dcc4e)
1.	The name is hashed and kept
2.	The file is encrypted.
